### PR TITLE
Only overwrite the config if installing latest

### DIFF
--- a/lib/tsd.js
+++ b/lib/tsd.js
@@ -24,13 +24,14 @@ function getRunner(logger) {
             var isLatest = setting.latest;
             var query;
 
+            opts.saveBundle = true;
             opts.overwriteFiles = true;
             opts.resolveDependencies = true;
-            opts.saveToConfig = true;
 
             logger.log('latest:', isLatest);
             logger.log('running...');
             if (isLatest) {
+                opts.saveToConfig = true;
                 query = new tsd.Query();
                 api.context.config.getInstalled().forEach(function (inst) {
                     var def = tsd.Def.getFrom(inst.path);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "tsd"
   ],
   "dependencies": {
-    "tsd": "~0.5.7",
+    "tsd": "git://github.com/Nemo157/tsd#write-bundle-without-tsd-json-0.5.7",
     "through2": "~0.4.2",
     "gulp-util": "~2.2.14"
   },


### PR DESCRIPTION
This causes issues when you're using changed file detection as part of your build, even though the config doesn't change the file is touched when this is set to true.

I'm not entirely sure why you want the config re-written in any cases, but I assume it's needed when you're using latest.
