### PR TITLE
Don't log when NODE_ENV=test

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ module.exports = function (options, callback) {
 
     var logger = {
         'log': function () {
+            if (process.env.NODE_ENV === 'test') {
+                return;
+            }
             var args = Array.prototype.slice.call(arguments);
             args.unshift('[' + gutil.colors.cyan('gulp-tsd') + ']');
             gutil.log.apply(undefined, args);


### PR DESCRIPTION
I adjusted the behavior of gulp-tsd to not log when node is in a testing environment. This will help to increase the readability of outputs from popular test frameworks (e.g. mocha, jasmine, etc.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/moznion/gulp-tsd/11)

<!-- Reviewable:end -->
