### PR TITLE
Add option to suppress build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ e.g.
 
 Please refer to the [tsd.json](https://github.com/DefinitelyTyped/tsd#tsdjson) to get more information.
 
+## OPTIONS
+
+In addition to options that should be passed directly to TSD, the following options may be passed:
+
+- quiet: Suppress command-line output
+
 ## NOTES
 
 A lot of codes are from [grunt-tsd](https://github.com/DefinitelyTyped/grunt-tsd). Thanks.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ module.exports = function (options, callback) {
 
     var logger = {
         'log': function () {
+            if (options.quiet) {
+                return;
+            }
+
             var args = Array.prototype.slice.call(arguments);
             args.unshift('[' + gutil.colors.cyan('gulp-tsd') + ']');
             gutil.log.apply(undefined, args);


### PR DESCRIPTION
Allow users to specify whether they'd like the extra logging or not.

By default, logging is enabled (no change), but by passing `quiet: true` to `gulp-tsd`, extra output will be silenced.