### PR TITLE
feat(logging): use npm 'debug' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ e.g.
 
 Please refer to the [tsd.json](https://github.com/DefinitelyTyped/tsd#tsdjson) to get more information.
 
+## DEBUGGING
+
+This library uses the popular [debug](https://github.com/visionmedia/debug) module for debugging.  To enable logging, set the `DEBUG` environment variable when running gulp tasks like so:
+
+```
+DEBUG=gulp-tsd gulp tsd
+```
+
 ## NOTES
 
 A lot of codes are from [grunt-tsd](https://github.com/DefinitelyTyped/grunt-tsd). Thanks.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var tsd     = require('./lib/tsd');
 var through = require('through2');
 var gutil   = require('gulp-util');
 var path    = require('path');
+var debug   = require('debug')('gulp-tsd');
 
 module.exports = function (options, callback) {
     'use strict';
@@ -13,9 +14,11 @@ module.exports = function (options, callback) {
 
     var logger = {
         'log': function () {
-            var args = Array.prototype.slice.call(arguments);
-            args.unshift('[' + gutil.colors.cyan('gulp-tsd') + ']');
-            gutil.log.apply(undefined, args);
+            var args = Array.prototype.slice.call(arguments),
+                printfString = Array.apply(null, Array(args.length)).map(function(){return '%o'}).join(' ');
+
+            args.unshift(printfString);
+            debug.apply(null, args);
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "tsd"
   ],
   "dependencies": {
+    "debug": "^2.2.0",
     "gulp-util": "^3.0.1",
     "through2": "^0.6.3",
     "tsd": "~0.6.0-beta.4"


### PR DESCRIPTION
This builds on https://github.com/moznion/gulp-tsd/pull/11 and https://github.com/moznion/gulp-tsd/pull/12 to allow configurable debugging by using the popular [debug](https://github.com/visionmedia/debug) module.  Debugging is off by default, but can be enabled by running:

```
DEBUG=gulp-tsd gulp tsd
```